### PR TITLE
Simplify HermiteSimpsonSolver.cs by extracting objective function computation

### DIFF
--- a/src/Optimal/Control/ObjectiveFunctionFactory.cs
+++ b/src/Optimal/Control/ObjectiveFunctionFactory.cs
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Small Trading Company Ltd (Destash.com).
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Optimal.Control
+{
+    /// <summary>
+    /// Factory for creating objective functions for collocation-based optimal control solvers.
+    /// </summary>
+    internal static class ObjectiveFunctionFactory
+    {
+        /// <summary>
+        /// Computes the total cost (running + terminal) for the given decision vector.
+        /// </summary>
+        public static double ComputeTotalCost(ControlProblem problem, ParallelTranscription transcription, double[] z)
+        {
+            var cost = 0.0;
+
+            if (problem.RunningCost != null)
+            {
+                double RunningCostValue(double[] x, double[] u, double t) => problem.RunningCost(x, u, t).value;
+                cost += transcription.ComputeRunningCost(z, RunningCostValue);
+            }
+
+            if (problem.TerminalCost != null)
+            {
+                double TerminalCostValue(double[] x, double t) => problem.TerminalCost(x, t).value;
+                cost += transcription.ComputeTerminalCost(z, TerminalCostValue);
+            }
+
+            return cost;
+        }
+
+        /// <summary>
+        /// Computes the gradient of the objective function.
+        /// </summary>
+        public static double[] ComputeObjectiveGradient(
+            ControlProblem problem,
+            CollocationGrid grid,
+            ParallelTranscription transcription,
+            double[] z)
+        {
+            if (!CanUseAnalyticalGradientsForCosts(problem))
+            {
+                return NumericalGradients.ComputeGradient(zz => ComputeTotalCost(problem, transcription, zz), z);
+            }
+
+            var gradient = new double[z.Length];
+
+            if (problem.RunningCost != null)
+            {
+                var runningGrad = AutoDiffGradientHelper.ComputeRunningCostGradient(
+                    problem, grid, z, transcription.GetState, transcription.GetControl,
+                    (x, u, t) =>
+                    {
+                        var res = problem.RunningCost!(x, u, t);
+                        return (res.value, res.gradients!);
+                    });
+
+                for (var i = 0; i < gradient.Length; i++)
+                {
+                    gradient[i] += runningGrad[i];
+                }
+            }
+
+            if (problem.TerminalCost != null)
+            {
+                var terminalGrad = AutoDiffGradientHelper.ComputeTerminalCostGradient(
+                    problem, grid, z, transcription.GetState,
+                    (x, t) =>
+                    {
+                        var res = problem.TerminalCost!(x, t);
+                        return (res.value, res.gradients!);
+                    });
+
+                for (var i = 0; i < gradient.Length; i++)
+                {
+                    gradient[i] += terminalGrad[i];
+                }
+            }
+
+            return gradient;
+        }
+
+        /// <summary>
+        /// Checks if analytical gradients can be used for cost computations.
+        /// </summary>
+        public static bool CanUseAnalyticalGradientsForCosts(ControlProblem problem)
+        {
+            var useAnalytical = true;
+
+            if (problem.RunningCost != null)
+            {
+                try
+                {
+                    var testResult = problem.RunningCost(new double[problem.StateDim], new double[problem.ControlDim], 0.0);
+                    var expectedSize = problem.StateDim + problem.ControlDim + 1;
+                    useAnalytical = useAnalytical && testResult.gradients != null && testResult.gradients.Length >= expectedSize;
+                }
+                catch
+                {
+                    useAnalytical = false;
+                }
+            }
+
+            if (problem.TerminalCost != null)
+            {
+                try
+                {
+                    var testResult = problem.TerminalCost(new double[problem.StateDim], 0.0);
+                    var expectedSize = problem.StateDim + 1;
+                    useAnalytical = useAnalytical && testResult.gradients != null && testResult.gradients.Length >= expectedSize;
+                }
+                catch
+                {
+                    useAnalytical = false;
+                }
+            }
+
+            return useAnalytical;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extracted objective function computation logic to new `ObjectiveFunctionFactory.cs` helper class
- Reduced `HermiteSimpsonSolver.cs` from 728 to 630 lines (~100 lines removed)
- Follows the pattern established by previous extraction of constraint configuration to `ConstraintConfigurator.cs`

## Changes

New `ObjectiveFunctionFactory` class contains:
- `ComputeTotalCost`: Computes combined running + terminal cost
- `ComputeObjectiveGradient`: Computes objective gradient using analytical or numerical methods  
- `CanUseAnalyticalGradientsForCosts`: Checks if analytical gradients are available for costs

## Test plan

- [x] All 22 HermiteSimpson-related tests pass
- [x] Build succeeds with no warnings/errors
- [x] No functional changes to solver behavior

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)