### PR TITLE
fix(autodiff): emit sign(x) for d|x|/dx instead of x/abs(x)

### DIFF
--- a/src/Optimal.AutoDiff/AutoDiff.Differentiation/MathFunctionRule.cs
+++ b/src/Optimal.AutoDiff/AutoDiff.Differentiation/MathFunctionRule.cs
@@ -559,11 +559,17 @@ namespace Optimal.AutoDiff.Analyzers.Differentiation
             var arg = methodCall.Arguments[0];
             var dArg = _differentiator.Differentiate(arg, context);
 
-            var sign = new BinaryOpNode(
+            // d/dx |x| = sign(x). Emit sign(x) rather than the algebraic x/abs(x):
+            // the latter is 0/0 = NaN at x = 0, which poisons the whole forward-mode
+            // gradient (and, in the WGSL SDF pipeline, produces NaN surface normals at
+            // grazing box-face hits where the in-face coordinate rounds exactly to the
+            // centre). sign(0) = 0 is a valid subgradient — and the correct value there
+            // by symmetry — and equals x/abs(x) everywhere else.
+            var sign = new MethodCallNode(
                 context.NewNodeId(),
-                BinaryOperator.Divide,
-                arg,
-                methodCall,
+                "Sign",
+                methodCall.MethodSymbol,
+                ImmutableArray.Create<IRNode>(arg),
                 _doubleType);
 
             return new BinaryOpNode(


### PR DESCRIPTION
## Problem
`DifferentiateAbs` (forward-mode IR rule) emitted `d|x|/dx = x/abs(x)`, which is **`0/0 = NaN` at `x = 0`**. Consumed by Dynamis' WGSL SDF-gradient pipeline, this produced **NaN surface normals at grazing box-face hits** (the long-standing "acne"), and was the latent bug that a hit-refinement experiment downstream catastrophically amplified.

## Fix
Emit **`sign(x)`** for `d|x|/dx`. `sign(0) = 0` is a valid subgradient (and the geometrically-correct value by symmetry), equals `x/abs(x)` for `x ≠ 0`, and is finite at the singularity. The IR bridge and codegen already recognise `Sign` as a differentiable math function, so no new plumbing is needed.

## Validation
- All AutoDiff tests pass (`AbsoluteValueGradient` still gets ±1 for x≠0 — `sign` is identical there).
- Downstream (Dynamis): the emitted gradient WGSL drops `x/abs(x)` 18→0, and grazing-angle renders are NaN-free.

## Note
The same `x/abs(x)` pattern also exists in `ForwardModeCodeGenerator` (CPU) and the reverse-mode codegen; left for a follow-up since those feed optimization, not the SDF renderer, and changing them alters NLP-gradient behaviour at kinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)